### PR TITLE
Add Slack get message from url tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These servers aim to demonstrate MCP features and the TypeScript and Python SDKs
 - **[Redis](src/redis)** - Interact with Redis key-value stores
 - **[Sentry](src/sentry)** - Retrieving and analyzing issues from Sentry.io
 - **[Sequential Thinking](src/sequentialthinking)** - Dynamic and reflective problem-solving through thought sequences
-- **[Slack](src/slack)** - Channel management and messaging capabilities
+ - **[Slack](src/slack)** - Channel management, messaging, and message retrieval capabilities
 - **[Sqlite](src/sqlite)** - Database interaction and business intelligence capabilities
 - **[Time](src/time)** - Time and timezone conversion capabilities
 

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -63,6 +63,12 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `user_id` (string): The user's ID
    - Returns: Detailed user profile information
 
+9. `slack_get_message_from_url`
+   - Fetch a single Slack message (including DMs) from a shared message URL
+   - Required inputs:
+     - `url` (string): The message link copied from Slack
+   - Returns: The Slack API response containing the message
+
 ## Setup
 
 1. Create a Slack App:


### PR DESCRIPTION
## Summary
- add `slack_get_message_from_url` tool and docs
- implement URL parsing and message fetching in Slack client
- handle the new tool and include it in tool listing
- document Slack message retrieval in root README

## Testing
- `npm run build` *(fails: cannot find module '@modelcontextprotocol/sdk/server/index.js')*
- `npm run build` in `src/slack` *(fails: cannot find module '@modelcontextprotocol/sdk/server/index.js')*
